### PR TITLE
show primary name first in report

### DIFF
--- a/ead/templates/views/reports/INFORMATION_RESOURCE.E73.htm
+++ b/ead/templates/views/reports/INFORMATION_RESOURCE.E73.htm
@@ -158,11 +158,21 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                                                 {% trans "No titles recorded" %}
                                                             </dd>
                                                         {% else %}
+                                                            
                                                             {% for TITLE_E41 in report_info.source.graph.TITLE_E41 %}
+                                                                {% if TITLE_E41.TITLE_TYPE_E55__value  == primary_name_label %}
                                                                 <dd class="arches-report-subsection-item">
                                                                     {{ TITLE_E41.TITLE_E41__value }} <span class="arches-report-subsection-item-type">({{TITLE_E41.TITLE_TYPE_E55__value}})</span>
                                                                 </dd>
-                                                            {% endfor %}            
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                            {% for TITLE_E41 in report_info.source.graph.TITLE_E41 %}
+                                                                {% if TITLE_E41.TITLE_TYPE_E55__value  != primary_name_label %}
+                                                                <dd class="arches-report-subsection-item">
+                                                                    {{ TITLE_E41.TITLE_E41__value }} <span class="arches-report-subsection-item-type">({{TITLE_E41.TITLE_TYPE_E55__value}})</span>
+                                                                </dd>
+                                                                {% endif %}
+                                                            {% endfor %}
                                                         {% endif %}
 
                                                     </dl>

--- a/ead/templates/views/reports/sections/NAME.E41.htm
+++ b/ead/templates/views/reports/sections/NAME.E41.htm
@@ -11,10 +11,20 @@
                     {% trans "No names recorded" %}
                 </dd>
             {% else %}
+                
                 {% for NAME_E41 in report_info.source.graph.NAME_E41 %}
+                    {% if NAME_E41.NAME_TYPE_E55__value  == primary_name_label %}
                     <dd class="arches-report-subsection-item">
                         {{ NAME_E41.NAME_E41__value }} <span class="arches-report-subsection-item-type">({{NAME_E41.NAME_TYPE_E55__value}})</span>
                     </dd>
+                    {% endif %}
+                {% endfor %}
+                {% for NAME_E41 in report_info.source.graph.NAME_E41 %}
+                    {% if NAME_E41.NAME_TYPE_E55__value  != primary_name_label %}
+                    <dd class="arches-report-subsection-item">
+                        {{ NAME_E41.NAME_E41__value }} <span class="arches-report-subsection-item-type">({{NAME_E41.NAME_TYPE_E55__value}})</span>
+                    </dd>
+                    {% endif %}
                 {% endfor %}            
             {% endif %}
 

--- a/ead/views/resources.py
+++ b/ead/views/resources.py
@@ -110,6 +110,9 @@ def report(request, resourceid):
     report_info['source']['graph'] = report_info['source']['graph']
     del report_info['_source']
     del report_info['_type']
+    
+    primary_label = settings.RESOURCE_TYPE_CONFIGS()[report_info['type']]['primary_name_lookup']['lookup_value'][1]
+    print "primary_label",primary_label
 
     def get_evaluation_path(valueid):
         value = models.Values.objects.get(pk=valueid)
@@ -256,7 +259,7 @@ def report(request, resourceid):
         centroid_coords = src['properties']['centroid']['coordinates']
     except:
         pass
-        
+    
     return render_to_response('resource-report.htm', {
             'geometry': JSONSerializer().serialize(report_info['source']['geometry']),
             'centroid_coords': centroid_coords,
@@ -268,6 +271,7 @@ def report(request, resourceid):
             'related_resource_dict': related_resource_dict,
             'related_resource_flag': related_resource_flag,
             'main_script': 'resource-report',
-            'active_page': 'ResourceReport'
+            'active_page': 'ResourceReport',
+            'primary_name_label': primary_label,
         },
         context_instance=RequestContext(request))        


### PR DESCRIPTION
completes #5 

Previously, these names were shown in the order that they had been entered in the database.