### PR TITLE
making sure the gred ref input isn't doubled #7

### DIFF
--- a/ead/templates/views/forms/location.htm
+++ b/ead/templates/views/forms/location.htm
@@ -269,10 +269,10 @@
                             <div class="col-sm-12">
                                 
                                 <!-- Form for screens > xs -->
+                                <div class="hidden-xs">
                                 <form class="form-inline arches-form hidden-xs" role="form">
                                     <div class="form-group" style="width: 100%">
                                         <input class="form-control" style="width: 50%; height: 32px;" id="address" placeholder="grid reference" data-bind='value: getEditedNode("GRID_REF.E42", "value")'>
-                                        
                                         <!-- Address Type -->
                                         <input style="width:30%; height: 36px; padding-top: 2px;" class="select2 arches-select2-crud-form address-type" placeholder="type" data-bind="select2: {value: getEditedNode('GRID_REF_TYPE.E55', 'value'), placeholder: 'Type', dataKey: 'GRID_REF_TYPE.E55'}">
                                         <!-- Address Type -->
@@ -281,6 +281,7 @@
 
                                     </div>
                                 </form>
+                                </div>
                                 <!-- End Form for screens > xs -->
 
                                 <!-- Form for screens = xs -->


### PR DESCRIPTION
I just wrapped another div around this section and added the `hidden-xs` class to that as well. I don't konw why the `form` element wasn't disappearing like it was supposed to.